### PR TITLE
Fix memory leaks in sformat()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with HDL Code Checker.  If not, see <http://www.gnu.org/licenses/>.
 ---
+dist: precise
 language: python
 python:
   - "2.7"

--- a/src/str_format_pkg.vhd
+++ b/src/str_format_pkg.vhd
@@ -5,12 +5,12 @@
 -- Copyright 2016 by Andre Souto (suoto)
 --
 -- This file is part of hdl_string_format.
--- 
+--
 -- hdl_string_format is free software: you can redistribute it and/or modify
 -- it under the terms of the GNU General Public License as published by
 -- the Free Software Foundation, either version 3 of the License, or
 -- (at your option) any later version.
--- 
+--
 -- hdl_string_format is distributed in the hope that it will be useful,
 -- but WITHOUT ANY WARRANTY; without even the implied warranty of
 -- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -924,6 +924,17 @@ package body str_format_pkg is
         A25, A26, A27, A28, A29, A30, A31, A32: in string := FIO_NIL
         ) return string is
         variable L      : line;
+
+        -- A helper function to prevent memory leaks.
+        -- Similar solution as in https://stackoverflow.com/a/42716392
+        impure function line_to_string return string is
+            variable ret : string (1 to L'length);
+        begin
+            ret := L.all;
+            deallocate(L);
+            return ret;
+        end function;
+
     begin
         fprint (L,
             format,
@@ -932,7 +943,7 @@ package body str_format_pkg is
             A17, A18, A19, A20, A21, A22, A23, A24,
             A25, A26, A27, A28, A29, A30, A31, A32);
 
-        return L.all;
+        return line_to_string;
     end function;
 
 end str_format_pkg;

--- a/src/test/str_format_tb.vhd
+++ b/src/test/str_format_tb.vhd
@@ -1,6 +1,6 @@
 --
 -- hdl_string_format -- VHDL package to provide C-like string formatting
--- 
+--
 -- Copyright 1995, 2001 by Jan Decaluwe/Easics NV (under the name PCK_FIO)
 -- Copyright 2016 by Andre Souto (suoto)
 --
@@ -29,20 +29,7 @@ library ieee;
     use ieee.numeric_std.all;
 
 library vunit_lib;
-    use vunit_lib.lang.all;
-    use vunit_lib.string_ops.all;
-    use vunit_lib.dictionary.all;
-    use vunit_lib.path.all;
-    use vunit_lib.log_types_pkg.all;
-    use vunit_lib.log_special_types_pkg.all;
-    use vunit_lib.log_pkg.all;
-    use vunit_lib.check_types_pkg.all;
-    use vunit_lib.check_special_types_pkg.all;
-    use vunit_lib.check_pkg.all;
-    use vunit_lib.run_types_pkg.all;
-    use vunit_lib.run_special_types_pkg.all;
-    use vunit_lib.run_base_pkg.all;
-    use vunit_lib.run_pkg.all;
+    context vunit_lib.vunit_context;
 
 library str_format;
     use str_format.str_format_pkg.all;
@@ -55,19 +42,6 @@ entity str_format_tb is
 end entity;
 
 architecture tb of str_format_tb is
-
-    procedure check_equal(
-        constant a, b      : in string;
-        line_num           : in natural := 0;
-        constant file_name : in string  := "") is
-    begin
-        info("a: " & '"' & a & '"');
-        info("b: " & '"' & a & '"');
-        if a /= b then
-            check_failed("Got " & '"' & a & '"' & ", expected " & '"' & b & '"',
-                         line_num => line_num, file_name => file_name);
-        end if;
-    end procedure;
 
     ---------------
     -- Constants --
@@ -92,7 +66,6 @@ begin
     ---------------
     main : process
         variable stat   : checker_stat_t;
-        variable filter : log_filter_t;
 
         --
         variable L       : line;
@@ -102,7 +75,7 @@ begin
         -- variable value : std_logic_vector(15 downto 0);
         constant value : std_logic_vector(15 downto 0) := x"1234";
 
-        impure function colorize (
+        impure function mycolorize (
             constant attributes : string) return string is
             variable lines      : lines_t := split(attributes, " ");
             constant attr_cnt   : integer := lines'length;
@@ -154,31 +127,21 @@ begin
         procedure cinfo(
             constant message : string) is
         begin
-            write(output, colorize("green"));
-            info(message & colorize("reset"));
-            -- write(output, colorize("reset"));
+            write(output, mycolorize("green"));
+            info(message & mycolorize("reset"));
+            -- write(output, mycolorize("reset"));
         end procedure;
 
         procedure cwarn(
             constant message : string) is
         begin
-            write(output, colorize("yellow"));
-            warning(message & colorize("reset"));
-            -- write(output, colorize("reset"));
+            write(output, mycolorize("yellow"));
+            warning(message & mycolorize("reset"));
+            -- write(output, mycolorize("reset"));
         end procedure;
 
 
     begin
-        checker_init(display_format => verbose,
-            file_name               => join(output_path(runner_cfg), "error.csv"),
-            file_format             => verbose_csv);
-
-        logger_init(display_format => verbose,
-            file_name              => join(output_path(runner_cfg), "log.csv"),
-            file_format            => verbose_csv);
-
-        stop_level((debug, verbose), display_handler, filter);
-
         test_runner_setup(runner, runner_cfg);
 
         while test_suite loop


### PR DESCRIPTION
`sformat()` causes memory leaks due to the line not deallocated before returning the string to the user.

I noticed the issue in a testbench where `check_equal(foo, bar, sformat("%d vs %d", fo(foo), fo(bar))` was executed in a tight loop.