### PR TITLE
Add printf procedure that reports directly to console

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ would look like
 report sformat("It's %d now", fo(2016));
 ```
 
+### printf
+
+Like `fprint` and `sformat`, but prints (`report`s) directly to console:
+
+```vhdl
+printf("It's %d now", fo(2016));
+```
+
 ### Format specifiers
 
 The general format of a format specifier is:

--- a/src/str_format_pkg.vhd
+++ b/src/str_format_pkg.vhd
@@ -75,6 +75,14 @@ package str_format_pkg is
         A25, A26, A27, A28, A29, A30, A31, A32: in string := FIO_NIL
         );
 
+    procedure printf (
+        constant format : in    string;
+        A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 : in string := FIO_NIL;
+        A9 , A10, A11, A12, A13, A14, A15, A16: in string := FIO_NIL;
+        A17, A18, A19, A20, A21, A22, A23, A24: in string := FIO_NIL;
+        A25, A26, A27, A28, A29, A30, A31, A32: in string := FIO_NIL
+    );
+
     function fo (constant arg: unsigned)          return string;
     function fo (constant arg: signed)            return string;
     function fo (constant arg: std_logic_vector)  return string;
@@ -771,6 +779,33 @@ package body str_format_pkg is
         deallocate(fmt);
 
     end fprint;
+
+
+
+    ----------------------------------------
+    -- Print (report) directly to console --
+    ----------------------------------------
+
+    procedure printf (
+        constant format : in    string;
+        A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 : in string := FIO_NIL;
+        A9 , A10, A11, A12, A13, A14, A15, A16: in string := FIO_NIL;
+        A17, A18, A19, A20, A21, A22, A23, A24: in string := FIO_NIL;
+        A25, A26, A27, A28, A29, A30, A31, A32: in string := FIO_NIL
+    ) is
+        variable L : line;
+    begin
+        fprint(
+            L,
+            format,
+            A1 , A2 , A3 , A4 , A5 , A6 , A7 , A8 ,
+            A9 , A10, A11, A12, A13, A14, A15, A16,
+            A17, A18, A19, A20, A21, A22, A23, A24,
+            A25, A26, A27, A28, A29, A30, A31, A32
+        );
+        report L.all;
+    end procedure;
+
 
 
     -------------------------------------------


### PR DESCRIPTION
Hey @suoto, this package is great.

For me it would be very useful to have a shorthand command that prints directly to console.

This PR adds the `printf` procedure so that you can do

`printf("It's %d now", fo(2016));`

instead of 

`report sformat("It's %d now", fo(2016));`

## About naming

I chose the name `printf` but I am open to revising that, if you think something else fits better.

I think these methods are inspired by their counterparts in C. 

* `sformat` matches the C function `sprintf`: https://www.tutorialspoint.com/c_standard_library/c_function_sprintf.htm
* `fprint` perhaps matches the C function `fprintf` (?): https://www.tutorialspoint.com/c_standard_library/c_function_fprintf.htm

So I chose `printf` for this new procedure since it matches the C function `printf`: https://www.tutorialspoint.com/c_standard_library/c_function_printf.htm